### PR TITLE
Add utility for safe updateFrom call with logging for debugging

### DIFF
--- a/src/utils/safeUpdateFrom.js
+++ b/src/utils/safeUpdateFrom.js
@@ -1,0 +1,12 @@
+// Utility function to safely call updateFrom if it exists
+export function safeUpdateFrom(obj, data) {
+  if (obj && typeof obj.updateFrom === 'function') {
+    obj.updateFrom(data);
+  } else {
+    console.warn('safeUpdateFrom: updateFrom method not found on object', obj);
+  }
+}
+
+// Example usage
+// import { safeUpdateFrom } from './utils/safeUpdateFrom';
+// safeUpdateFrom(someObject, someData);


### PR DESCRIPTION
This PR adds a utility function `safeUpdateFrom` that safely calls the `updateFrom` method on an object if it exists. It includes logging for cases where the method is not found. This helps prevent errors like "Object [object Object] has no method 'updateFrom'" and aids debugging by logging the object state.

Example usage is included in comments. Please adapt this utility in your codebase where `updateFrom` is called to improve robustness and gather debugging information.